### PR TITLE
Updates for MDI library based on static code analysis with Coverity Scan

### DIFF
--- a/MDI_Library/mdi_general.c
+++ b/MDI_Library/mdi_general.c
@@ -857,11 +857,11 @@ int register_node(vector* node_vec, const char* node_name)
   int node_index;
   ret = get_node_index(node_vec, node_name, &node_index);
   if ( ret != 0 ) {
-    mdi_error("Error in register_node: get_node_index failed"); 
+    mdi_error("Error in register_node: get_node_index failed");
     return 1;
   }
   if ( node_index != -1 ) {
-    mdi_error("This node is already registered"); 
+    mdi_error("This node is already registered");
     return 1;
   }
 
@@ -924,7 +924,7 @@ int register_command(vector* node_vec, const char* node_name, const char* comman
   int node_index;
   ret = get_node_index(node_vec, node_name, &node_index);
   if ( ret != 0 ) {
-    mdi_error("Error in register_command: get_node_index failed"); 
+    mdi_error("Error in register_command: get_node_index failed");
     return 1;
   }
   if ( node_index == -1 ) {
@@ -938,7 +938,7 @@ int register_command(vector* node_vec, const char* node_name, const char* comman
   int command_index;
   ret = get_command_index(target_node, command_name, &command_index);
   if ( ret != 0 ) {
-    mdi_error("Error in register_command: get_command_index failed"); 
+    mdi_error("Error in register_command: get_command_index failed");
     return 1;
   }
   if ( command_index != -1 ) {
@@ -1001,7 +1001,7 @@ int register_callback(vector* node_vec, const char* node_name, const char* callb
   int node_index;
   ret = get_node_index(node_vec, node_name, &node_index);
   if ( ret != 0 ) {
-    mdi_error("Error in register_callback: get_node_index failed"); 
+    mdi_error("Error in register_callback: get_node_index failed");
     return 1;
   }
   if ( node_index == -1 ) {
@@ -1015,7 +1015,7 @@ int register_callback(vector* node_vec, const char* node_name, const char* callb
   int callback_index;
   ret = get_callback_index(target_node, callback_name, &callback_index);
   if ( ret != 0 ) {
-    mdi_error("Error in register_callback: get_callback_index failed"); 
+    mdi_error("Error in register_callback: get_callback_index failed");
     return 1;
   }
   if ( callback_index != -1 ) {
@@ -1064,13 +1064,13 @@ int send_command_list(MDI_Comm comm) {
     mdi_error("Attempting to send command information from the incorrect rank");
     return 1;
   }
-  
+
   // Use the smaller of MDI_COMMAND_LENGTH between the two codes
   int clength = MDI_COMMAND_LENGTH_;
   if ( this_comm->command_length < MDI_COMMAND_LENGTH_ ) {
     clength = this_comm->command_length;
   }
-  
+
   int ncommands = 0;
   int nnodes = (int)this_code->nodes->size;
   int inode, icommand;
@@ -1114,13 +1114,13 @@ int send_command_list(MDI_Comm comm) {
       length = (int)strlen(command);
       snprintf(&commands[ islot * stride ], clength, "%s", command);
       for (ichar = length; ichar < stride-1; ichar++) {
-	commands[ islot * stride + ichar ] = ' ';
+        commands[ islot * stride + ichar ] = ' ';
       }
       if ( icommand == this_node->commands->size - 1 ) {
-	commands[ islot * stride + stride - 1 ] = ';';
+        commands[ islot * stride + stride - 1 ] = ';';
       }
       else {
-	commands[ islot * stride + stride - 1 ] = ',';
+        commands[ islot * stride + stride - 1 ] = ',';
       }
       islot++;
     }
@@ -1163,13 +1163,13 @@ int send_callback_list(MDI_Comm comm) {
   int ncallbacks = 0;
   int nnodes = (int)this_code->nodes->size;
   int inode, icallback;
-  
+
   // Use the smaller of MDI_COMMAND_LENGTH between the two codes
   int clength = MDI_COMMAND_LENGTH_;
   if ( this_comm->command_length < MDI_COMMAND_LENGTH_ ) {
     clength = this_comm->command_length;
   }
-  
+
   int stride = clength + 1;
 
   // determine the number of callbakcs
@@ -1214,13 +1214,13 @@ int send_callback_list(MDI_Comm comm) {
       length = (int)strlen(callback);
       snprintf(&callbacks[ islot * stride ], clength, "%s", callback);
       for (ichar = length; ichar < stride-1; ichar++) {
-	callbacks[ islot * stride + ichar ] = ' ';
+        callbacks[ islot * stride + ichar ] = ' ';
       }
       if ( icallback == this_node->callbacks->size - 1 ) {
-	callbacks[ islot * stride + stride - 1 ] = ';';
+        callbacks[ islot * stride + stride - 1 ] = ';';
       }
       else {
-	callbacks[ islot * stride + stride - 1 ] = ',';
+        callbacks[ islot * stride + stride - 1 ] = ',';
       }
       islot++;
     }
@@ -1604,7 +1604,7 @@ int get_node_info(MDI_Comm comm) {
     // free the memory for the node name
     free( callback_name );
   }
-  
+
   // free the memory
   free( node_list );
   free( commands );
@@ -1620,7 +1620,7 @@ int get_node_info(MDI_Comm comm) {
  * The function returns the node vector for the communicator.
  *
  * \param [in]       comm
- *                   MDI communicator of the engine.  If comm is set to 
+ *                   MDI communicator of the engine.  If comm is set to
  *                   MDI_COMM_NULL, the function will return the node vector for the calling engine.
  */
 int get_node_vector(MDI_Comm comm, vector** vector_ptr) {

--- a/MDI_Library/mdi_general.c
+++ b/MDI_Library/mdi_general.c
@@ -124,11 +124,15 @@ int general_init(const char* options) {
     //-role
     if (strcmp(argv[iarg],"-role") == 0){
       if (iarg+2 > argc) {
+        free(argv);
+        free(argv_line);
         mdi_error("Error in MDI_Init: Argument missing from -role option");
         return 1;
       }
       role = argv[iarg+1];
       if ( strlen(role) > MDI_NAME_LENGTH_ ) {
+        free(argv);
+        free(argv_line);
         mdi_error("Error in MDI_Init: Role option is larger than MDI_NAME_LENGTH");
         return 1;
       }
@@ -139,6 +143,8 @@ int general_init(const char* options) {
     //-method
     else if (strcmp(argv[iarg],"-method") == 0) {
       if (iarg+2 > argc) {
+        free(argv);
+        free(argv_line);
         mdi_error("Error in MDI_Init: Argument missing from -method option");
         return 1;
       }
@@ -149,10 +155,14 @@ int general_init(const char* options) {
     //-name
     else if (strcmp(argv[iarg],"-name") == 0){
       if (iarg+2 > argc) {
+        free(argv);
+        free(argv_line);
         mdi_error("Error in MDI_Init: Argument missing from -name option");
         return 1;
       }
       if ( strlen(argv[iarg+1]) > MDI_NAME_LENGTH_ ) {
+        free(argv);
+        free(argv_line);
         mdi_error("Error in MDI_Init: Name argument length exceeds MDI_NAME_LENGTH");
         return 1;
       }
@@ -163,6 +173,8 @@ int general_init(const char* options) {
     //-hostname
     else if (strcmp(argv[iarg],"-hostname") == 0){
       if (iarg+2 > argc) {
+        free(argv);
+        free(argv_line);
         mdi_error("Error in MDI_Init: Argument missing from -hostname option");
         return 1;
       }
@@ -172,6 +184,8 @@ int general_init(const char* options) {
     //-port
     else if (strcmp(argv[iarg],"-port") == 0) {
       if (iarg+2 > argc) {
+        free(argv);
+        free(argv_line);
         mdi_error("Error in MDI_Init: Argument missing from -port option");
         return 1;
       }
@@ -186,6 +200,8 @@ int general_init(const char* options) {
     //-out
     else if (strcmp(argv[iarg],"-out") == 0) {
       if (iarg+2 > argc) {
+        free(argv);
+        free(argv_line);
         mdi_error("Error in MDI_Init: Argument missing from -out option");
         return 1;
       }
@@ -196,10 +212,14 @@ int general_init(const char* options) {
     //-plugin_path
     else if (strcmp(argv[iarg],"-plugin_path") == 0) {
       if (iarg+2 > argc) {
+        free(argv);
+        free(argv_line);
         mdi_error("Error in MDI_Init: Argument missing from -plugin_path option");
         return 1;
       }
       if ( strlen(argv[iarg+1]) > PLUGIN_PATH_LENGTH ) {
+        free(argv);
+        free(argv_line);
         mdi_error("Error in MDI_Init: Plugin path is larger than PLUGIN_PATH_LENGTH");
         return 1;
       }
@@ -210,6 +230,8 @@ int general_init(const char* options) {
     //_language
     else if (strcmp(argv[iarg],"_language") == 0) {
       if (iarg+2 > argc) {
+        free(argv);
+        free(argv_line);
         mdi_error("Error in MDI_Init: Argument missing from -_language option");
         return 1;
       }
@@ -221,11 +243,16 @@ int general_init(const char* options) {
         this_code->language = MDI_LANGUAGE_FORTRAN;
       }
       else {
-        mdi_error("Error in MDI_Init: Invalide -_language argument");
+        free(argv);
+        free(argv_line);
+        mdi_error("Error in MDI_Init: Invalid -_language argument");
+        return 1;
       }
       iarg += 2;
     }
     else {
+      free(argv);
+      free(argv_line);
       mdi_error("Error in MDI_Init: Unrecognized option");
       return 1;
     }
@@ -1255,6 +1282,7 @@ int send_node_list(MDI_Comm comm) {
     ret = vector_get(this_code->nodes, inode, (void**)&this_node);
     int length = (int)strlen(this_node->name);
     if ( strlen(this_node->name) >= MDI_COMMAND_LENGTH_ ) {
+      free(node_list);
       mdi_error("Error in send_node_list: Node name is larger than MDI_COMMAND_LENGTH");
       return 1;
     }
@@ -1502,6 +1530,7 @@ int get_node_info(MDI_Comm comm) {
       node_flag = 0;
     }
     else {
+      free(command_name);
       mdi_error("Error obtaining node information: could not parse delimiter");
       return 1;
     }

--- a/MDI_Library/mdi_general.c
+++ b/MDI_Library/mdi_general.c
@@ -1455,6 +1455,7 @@ int get_node_info(MDI_Comm comm) {
       name_length = (int)(name_end - name_start);
     }
     if ( name_length >= MDI_COMMAND_LENGTH_ ) {
+      free(current_node);
       mdi_error("Error obtaining node information: could not parse node name");
       return 1;
     }

--- a/MDI_Library/mdi_general.c
+++ b/MDI_Library/mdi_general.c
@@ -1279,7 +1279,7 @@ int send_node_list(MDI_Comm comm) {
   for (inode = 0; inode < nnodes; inode++) {
     // add the name of this node to the list
     node* this_node;
-    ret = vector_get(this_code->nodes, inode, (void**)&this_node);
+    vector_get(this_code->nodes, inode, (void**)&this_node);
     int length = (int)strlen(this_node->name);
     if ( strlen(this_node->name) >= MDI_COMMAND_LENGTH_ ) {
       free(node_list);
@@ -1328,7 +1328,7 @@ int send_ncommands(MDI_Comm comm) {
   // determine the number of commands
   for (inode = 0; inode < nnodes; inode++) {
     node* this_node;
-    ret = vector_get(this_code->nodes, inode, (void**)&this_node);
+    vector_get(this_code->nodes, inode, (void**)&this_node);
     ncommands += (int)this_node->commands->size;
   }
 

--- a/MDI_Library/mdi_global.c
+++ b/MDI_Library/mdi_global.c
@@ -348,7 +348,7 @@ int new_code(size_t* code_id) {
 
   // return the index of the new code
   *code_id = codes.size - 1;
-  
+
   return 0;
 }
 
@@ -729,7 +729,7 @@ int delete_communicator(size_t code_id, MDI_Comm_Type comm_id) {
     }
   }
   if ( comm_found != 1 ) {
-    mdi_error("Communicator not found during delete"); 
+    mdi_error("Communicator not found during delete");
     return 1;
   }
 
@@ -962,8 +962,8 @@ int datatype_mpitype(MDI_Datatype_Type datatype, MPI_Datatype* mpitype) {
 
 /*! \brief Convert a buffer from one datatype to another */
 int convert_buf_datatype(void* recvbuf_in, MDI_Datatype_Type recvtype,
-			 void* sendbuf_in, MDI_Datatype_Type sendtype,
-			 int count) {
+                         void* sendbuf_in, MDI_Datatype_Type sendtype,
+                         int count) {
   int ii;
 
   if ( sendtype == MDI_INT_ ) {
@@ -1027,7 +1027,7 @@ int convert_buf_datatype(void* recvbuf_in, MDI_Datatype_Type recvtype,
       mdi_error("Unrecognized datatype in convert_buf_datatype.");
       return 1;
     }
-    
+
   }
   else if ( sendtype == MDI_INT8_T_ ) {
     int8_t* sendbuf = (int8_t*) sendbuf_in;

--- a/MDI_Library/mdi_global.c
+++ b/MDI_Library/mdi_global.c
@@ -1344,7 +1344,7 @@ int convert_buf_datatype(void* recvbuf_in, MDI_Datatype_Type recvtype,
     }
 
   }
-  else if ( sendtype == MDI_UINT64_T_ ) {
+  else if ( sendtype == MDI_UINT16_T_ ) {
     uint16_t* sendbuf = (uint16_t*) sendbuf_in;
 
     if ( recvtype == MDI_INT_ ) {
@@ -1407,7 +1407,7 @@ int convert_buf_datatype(void* recvbuf_in, MDI_Datatype_Type recvtype,
     }
 
   }
-  else if ( sendtype == MDI_UINT64_T_ ) {
+  else if ( sendtype == MDI_UINT32_T_ ) {
     uint32_t* sendbuf = (uint32_t*) sendbuf_in;
 
     if ( recvtype == MDI_INT_ ) {

--- a/MDI_Library/mdi_global.c
+++ b/MDI_Library/mdi_global.c
@@ -313,6 +313,8 @@ int new_code(size_t* code_id) {
   vector* node_vec = malloc(sizeof(vector));
   ret = vector_init(node_vec, sizeof(node));
   if ( ret != 0 ) {
+    free(new_code);
+    free(node_vec);
     mdi_error("Error in new_code: could not initialize node vector");
     return ret;
   }

--- a/MDI_Library/mdi_lib.c
+++ b/MDI_Library/mdi_lib.c
@@ -397,6 +397,8 @@ int library_load_init(const char* plugin_name, void* mpi_comm_ptr,
     // Initialize an instance of the plugin
     ret = libd->plugin_init( libd->shared_state );
     if ( ret != 0 ) {
+      free( plugin_path );
+      free( plugin_init_name );
       mdi_error("MDI plugin init function returned non-zero exit code");
       return -1;
     }

--- a/MDI_Library/mdi_lib.c
+++ b/MDI_Library/mdi_lib.c
@@ -254,7 +254,7 @@ int plug_on_recv_command(MDI_Comm comm) {
   libd->shared_state->execute_command_obj = this_code->execute_command_obj;
 
   // set the current code to the driver
-  libd->shared_state->driver_activate_code( libd->shared_state->driver_codes_ptr, 
+  libd->shared_state->driver_activate_code( libd->shared_state->driver_codes_ptr,
                                             libd->shared_state->driver_code_id );
 
   void* mpi_ptr = libd->shared_state->mpi_comm_ptr;
@@ -474,7 +474,7 @@ int library_parse_options(const char* options, library_data* libd) {
       in_double_quotes = (in_double_quotes + 1) % 2;
       libd->shared_state->plugin_options[ichar] = '\0';
     }
-    else if (libd->shared_state->plugin_options[ichar] == '\'') { 
+    else if (libd->shared_state->plugin_options[ichar] == '\'') {
       if ( in_double_quotes ) {
         mdi_error("Nested quotes not supported by MDI_Launch_plugin \"options\" argument.");
       }
@@ -736,7 +736,7 @@ int library_open_plugin(const char* plugin_name, const char* options, void* mpi_
   libd->shared_state->driver_activate_code = library_activate_code;
   libd->shared_state->driver_callback_obj = libd->driver_callback_obj;
 
-  // Assign the global command-line options variables to the values for this plugin  
+  // Assign the global command-line options variables to the values for this plugin
   //plugin_argc = libd->shared_state->plugin_argc;
   //plugin_argv = libd->shared_state->plugin_argv;
   //plugin_unedited_options = libd->plugin_unedited_options;
@@ -817,7 +817,7 @@ int library_close_plugin(MDI_Comm mdi_comm) {
   // Delete the driver's communicator to the engine
   // This will also delete the engine code and its communicator
   delete_communicator(codes.current_key, mdi_comm);
-  
+
   return 0;
 }
 
@@ -917,7 +917,7 @@ int library_initialize() {
     else {
       this_code->intra_rank = 0;
     }
-      
+
     libd->shared_state->intra_rank = this_code->intra_rank;
 
   }
@@ -1272,7 +1272,7 @@ int library_recv(void* buf, int count, MDI_Datatype datatype, MDI_Comm comm, int
   // receive message header information
   // only do this if communicating with MDI version 1.1 or higher
   if ( ( this->mdi_version[0] > 1 ||
-	 ( this->mdi_version[0] == 1 && this->mdi_version[1] >= 1 ) )
+         ( this->mdi_version[0] == 1 && this->mdi_version[1] >= 1 ) )
        && this_code->ipi_compatibility != 1 ) {
 
     if ( msg_flag == 1 ) { // message header
@@ -1441,7 +1441,7 @@ int library_set_state(void* state) {
 
   plugin_shared_state* shared_state = (plugin_shared_state*) state;
 
-  ret = MDI_Init_with_argv(&shared_state->plugin_argc, 
+  ret = MDI_Init_with_argv(&shared_state->plugin_argc,
                            &shared_state->plugin_argv);
   if ( ret != 0 ) {
     return ret;

--- a/MDI_Library/mdi_lib.c
+++ b/MDI_Library/mdi_lib.c
@@ -181,6 +181,7 @@ int plug_on_send_command(const char* command, MDI_Comm comm, int* skip_flag) {
     ret = get_communicator(codes.current_key, comm, &this);
     if ( ret != 0 ) {
       mdi_error("Error in plug_on_send_command: second get_communicator failed");
+      free( command_bcast );
       return ret;
     }
     library_data* libd = (library_data*) this->method_data;

--- a/MDI_Library/mdi_mpi.c
+++ b/MDI_Library/mdi_mpi.c
@@ -376,7 +376,9 @@ int mpi_identify_codes(const char* code_name, int use_mpi4py, MPI_Comm world_com
     }
   }
   if ( driver_rank == -1 ) {
-    mdi_error("Unable to identify driver when attempting to connect via MPI"); 
+    free(name);
+    free(unique_names);
+    mdi_error("Unable to identify driver when attempting to connect via MPI");
     return 1;
   }
 

--- a/MDI_Library/mdi_mpi.c
+++ b/MDI_Library/mdi_mpi.c
@@ -359,6 +359,7 @@ int mpi_identify_codes(const char* code_name, int use_mpi4py, MPI_Comm world_com
   else {
     ret = this_code->mpi4py_gather_names_callback(buffer, names, name_lengths, name_displs);
     if ( ret != 0 ) {
+      free(unique_names);
       mdi_error("Error in mpi4py_gather_names_callback");
       return ret;
     }

--- a/MDI_Library/mdi_mpi.c
+++ b/MDI_Library/mdi_mpi.c
@@ -238,7 +238,7 @@ int mpi_after_send_command(const char* command, MDI_Comm comm) {
       MPI_Finalize();
     }
   }
-  
+
   return 0;
 }
 
@@ -256,7 +256,7 @@ int mpi_on_recv_command(MDI_Comm comm) {
  * If use_mpi4py == 0, this function will call MPI_Comm_split to create an intra-code communicator for each code.
  *
  * \param [in]       code_name
- *                   MDI name of the code associated with this process, indicated by the user with the -name 
+ *                   MDI name of the code associated with this process, indicated by the user with the -name
  *                   runtime option.
  * \param [in]       use_mpi4py
  *                   Flag to indicate whether MPI_Comm_split should be called in order to create an intra-code
@@ -304,7 +304,7 @@ int mpi_identify_codes(const char* code_name, int use_mpi4py, MPI_Comm world_com
   my_version[3] = MDI_COMMAND_LENGTH;
   my_version[4] = MDI_NAME_LENGTH;
   if ( use_mpi4py == 0 ) {
-    MPI_Allgather(my_version, 5, MPI_INT, all_versions, 5, 
+    MPI_Allgather(my_version, 5, MPI_INT, all_versions, 5,
         MPI_INT, world_comm);
   }
   else {
@@ -351,7 +351,7 @@ int mpi_identify_codes(const char* code_name, int use_mpi4py, MPI_Comm world_com
   // gather the name of the code associated with each rank
   if ( use_mpi4py == 0 ) {
     //MPI_Allgather(buffer, MDI_NAME_LENGTH, MPI_CHAR, names, MDI_NAME_LENGTH,
-	//	  MPI_CHAR, world_comm);
+        //        MPI_CHAR, world_comm);
     MPI_Allgatherv(buffer, MDI_NAME_LENGTH, MPI_CHAR, names,
         name_lengths, name_displs,
         MPI_CHAR, world_comm);
@@ -371,7 +371,7 @@ int mpi_identify_codes(const char* code_name, int use_mpi4py, MPI_Comm world_com
     if ( driver_rank == -1 ) {
       memcpy( name, &names[i*MDI_NAME_LENGTH], MDI_NAME_LENGTH );
       if ( strcmp(name, "") == 0 ) {
-	driver_rank = i;
+        driver_rank = i;
       }
     }
   }
@@ -393,7 +393,7 @@ int mpi_identify_codes(const char* code_name, int use_mpi4py, MPI_Comm world_com
     for (j=0; j<i; j++) {
       memcpy( prev_name, &names[j*MDI_NAME_LENGTH], MDI_NAME_LENGTH );
       if ( strcmp(name, prev_name) == 0 ) {
-	found = 1;
+        found = 1;
       }
     }
 

--- a/MDI_Library/mdi_plug_py.c
+++ b/MDI_Library/mdi_plug_py.c
@@ -10,7 +10,7 @@
 int print_traceback()
 {
   // Function to print the Python traceback
-  
+
   PyObject *ptype, *pvalue, *ptraceback;
   PyObject *traceback_module;
   char *c_traceback;
@@ -22,11 +22,11 @@ int print_traceback()
     PyObject *traceback_list, *empty_str, *traceback_pystr;
 
     traceback_list = PyObject_CallMethod(traceback_module,
-					 "format_exception",
-					 "OOO",
-					 ptype,
-					 pvalue == NULL ? Py_None : pvalue,
-					 ptraceback == NULL ? Py_None : ptraceback);
+                                         "format_exception",
+                                         "OOO",
+                                         ptype,
+                                         pvalue == NULL ? Py_None : pvalue,
+                                         ptraceback == NULL ? Py_None : ptraceback);
 
 #if PY_MAJOR_VERSION >= 3
     empty_str = PyUnicode_FromString("");

--- a/MDI_Library/mdi_plug_py.c
+++ b/MDI_Library/mdi_plug_py.c
@@ -158,6 +158,7 @@ int python_plugin_init( const char* engine_name, const char* engine_path, void* 
                     Py_file_input,
                     main_dict, main_dict);
     if ( PyErr_Occurred() ) {
+      fclose(engine_script);
       mdi_error("Unable to set system properties for Python plugin");
       print_traceback();
       return 1;

--- a/MDI_Library/mdi_tcp.c
+++ b/MDI_Library/mdi_tcp.c
@@ -374,6 +374,11 @@ int tcp_request_connection(int port_in, char* hostname_ptr) {
   communicator* new_comm;
   ret = get_communicator(this_code->id, comm_id, &new_comm);
   if ( ret != 0 ) {
+#if _WIN32
+    closesocket(sockfd);
+#else
+    close(sockfd);
+#endif
     mdi_error("Error in tcp_request_connection: get_communicator failed");
     return ret;
   }


### PR DESCRIPTION
When enabling static code analysis in LAMMPS for the MDI package with Coverity Scan (https://scan.coverity.com/) also several issues were reported for the MDI library.

This pull request tries to address them. Most are peripheral and have only a minor impact, but the change in commit 78bc193021a9b099982249dbc18f1c16b8a3db13 is a real bugfix.

Please also check out issue #158 